### PR TITLE
login: auth 기능 완성

### DIFF
--- a/src/main/java/com/todos/mmd/auth/api/AuthController.java
+++ b/src/main/java/com/todos/mmd/auth/api/AuthController.java
@@ -3,16 +3,17 @@ package com.todos.mmd.auth.api;
 import com.todos.mmd.auth.api.response.TokenResponse;
 import com.todos.mmd.auth.application.AuthService;
 import com.todos.mmd.auth.api.request.AuthRequest;
-import com.todos.mmd.auth.application.UserDetailsImpl;
+import com.todos.mmd.auth.application.MemberDetails;
 import com.todos.mmd.auth.application.dto.AdminCreateDto;
 import com.todos.mmd.auth.application.dto.LoginDto;
 import com.todos.mmd.auth.application.dto.MemberCreateDto;
-import com.todos.mmd.auth.domain.Member;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.*;
 
 import javax.validation.Valid;
@@ -48,8 +49,8 @@ public class AuthController {
 
     /* access 토큰 재발급 */
     @GetMapping("/reissue")
-    public ResponseEntity<TokenResponse> reissue(@AuthenticationPrincipal UserDetailsImpl userDetails) {
-        TokenResponse token = authService.reissue(userDetails);
+    public ResponseEntity<TokenResponse> reissue(@AuthenticationPrincipal MemberDetails memberDetails) {
+        TokenResponse token = authService.reissue(memberDetails);
         return ResponseEntity.ok(token);
     }
 

--- a/src/main/java/com/todos/mmd/auth/application/AuthService.java
+++ b/src/main/java/com/todos/mmd/auth/application/AuthService.java
@@ -12,6 +12,7 @@ import com.todos.mmd.repository.member.MemberRepository;
 import com.todos.mmd.repository.redis.RefreshTokenRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -76,8 +77,8 @@ public class AuthService {
     }
 
     /* 토큰 재발급 */
-    public TokenResponse reissue(UserDetailsImpl userDetails) {
-        return jwtTokenProvider.reissueAccessToken(userDetails.getUsername(), userDetails.getAuthorities().toString());
+    public TokenResponse reissue(MemberDetails memberDetails) {
+        return jwtTokenProvider.reissueAccessToken(memberDetails.getUsername(), memberDetails.getAuthorities().toString());
     }
 
     /* 로그아웃 */

--- a/src/main/java/com/todos/mmd/auth/application/MemberDetails.java
+++ b/src/main/java/com/todos/mmd/auth/application/MemberDetails.java
@@ -10,7 +10,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 @RequiredArgsConstructor
-public class UserDetailsImpl implements UserDetails {
+public class MemberDetails implements UserDetails {
     private final Member member;
     private static final String ROLE_PREFIX = "ROLE_";
 
@@ -22,7 +22,7 @@ public class UserDetailsImpl implements UserDetails {
 
     @Override
     public String getPassword() {
-        return member.getPassword();
+        return null;
     }
 
     @Override

--- a/src/main/java/com/todos/mmd/auth/application/MemberDetailsService.java
+++ b/src/main/java/com/todos/mmd/auth/application/MemberDetailsService.java
@@ -6,19 +6,18 @@ import com.todos.mmd.repository.member.MemberRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
-import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.stereotype.Service;
 
 @RequiredArgsConstructor
 @Service
-public class UserDetailsServiceImpl implements UserDetailsService {
+public class MemberDetailsService implements UserDetailsService {
 
     private final MemberRepository memberRepository;
 
     @Override
-    public UserDetails loadUserByUsername(String email) throws UsernameNotFoundException {
+    public UserDetails loadUserByUsername(String email) {
         Member member = memberRepository.findByEmail(email)
                 .orElseThrow(() -> new AuthException("존재하지 않는 계정입니다."));
-        return new UserDetailsImpl(member);
+        return new MemberDetails(member);
     }
 }

--- a/src/main/java/com/todos/mmd/auth/application/util/JwtAuthFilter.java
+++ b/src/main/java/com/todos/mmd/auth/application/util/JwtAuthFilter.java
@@ -36,18 +36,6 @@ public class JwtAuthFilter extends OncePerRequestFilter {
             Authentication authentication = jwtTokenProvider.extractAuthentication(accessToken);
             SecurityContextHolder.getContext().setAuthentication(authentication);
         }
-//        else if (StringUtils.hasText(refreshToken) && !jwtTokenProvider.validateToken(accessToken) && jwtTokenProvider.validateToken(refreshToken) && tokenService.isExists(refreshToken)) {
-//
-//            // refresh 토큰 정보로 Authentication 객체 생성 및 저장
-//            Authentication authentication = jwtTokenProvider.extractAuthentication(refreshToken);
-//
-//            // accessToken과 refreshToken 재발급
-//            TokenResponse tokenResponse = jwtTokenProvider.generate(authentication.getName(), authentication.getAuthorities().toString());
-//
-//            tokenService.saveMemberRefreshToken(authentication.getName(), tokenResponse.getRefreshToken());
-//
-//            SecurityContextHolder.getContext().setAuthentication(authentication);
-//        }
 
         filterChain.doFilter(request, response);
     }

--- a/src/main/java/com/todos/mmd/global/config/WebSecurityConfig.java
+++ b/src/main/java/com/todos/mmd/global/config/WebSecurityConfig.java
@@ -1,6 +1,5 @@
 package com.todos.mmd.global.config;
 
-import com.todos.mmd.auth.application.util.JwtAccessDeniedHandler;
 import com.todos.mmd.auth.application.util.JwtAuthFilter;
 import com.todos.mmd.auth.application.util.JwtAuthenticationEntryPoint;
 import lombok.RequiredArgsConstructor;
@@ -24,15 +23,14 @@ public class WebSecurityConfig {
     private final JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
     private static final String[] ALLOWED_URIS = {"/api/auth/**"};
 
-
-    @Bean
-    public WebSecurityCustomizer webSecurityCustomizer() {
-        return web -> {
-            web.ignoring()
-                    .antMatchers(
-                    );
-        };
-    }
+//    @Bean
+//    public WebSecurityCustomizer webSecurityCustomizer() {
+//        return web -> {
+//            web.ignoring()
+//                    .antMatchers(
+//                    );
+//        };
+//    }
 
     /* filterChain 설정 */
     @Bean

--- a/src/main/resources/docker-compose.yml
+++ b/src/main/resources/docker-compose.yml
@@ -1,0 +1,18 @@
+version: "3.0"
+services:
+#  web:
+#    image: redis
+#    container_name: mmd_redis
+#    ports:
+#      - "6379:6379"
+
+  redis-container:
+    image: redis:latest
+    container_name: mmd_redis
+    command: redis-server
+    hostname: redis
+    ports:
+      - 6379:6379
+    restart: always
+
+


### PR DESCRIPTION
일단 완성했는데 해결해야 할 부분이 있다.
reissue시 로그인된 사용자 정보를 얻기 위해서 UsernameToken을 생성할 때 principal로 memberDetails를 넘기게 되는데,
memberDetails에서는 member 객체를 자동으로 주입받고있다.
이렇게 되면 member객체의 모든 정보가 넘겨져서 불필요하거나 예민한 정보(비밀번호 등) 까지 접근할 수 있게된다.

하지만 principal로 memberDetails 자체를 넘기지 않으면 null로 들어가기 때문에 어떻게 해야할 지 모르겠음~